### PR TITLE
Add missing use statement and fix fatal error

### DIFF
--- a/FindologicSearch/Components/Findologic/Export.php
+++ b/FindologicSearch/Components/Findologic/Export.php
@@ -1231,7 +1231,9 @@ WHERE a.active = 1 AND a.name <> '' AND ". $query . " AND ad.kind = 1 AND ad.act
             $mainPrices = [];
             /** @var \Shopware\Models\Article\Price $price */
             foreach ($mainPrice as $price) {
-                $mainPrices[$price->getCustomerGroup()->getKey()] = $price->getPrice();
+                if ($price->getCustomerGroup()) {
+                    $mainPrices[$price->getCustomerGroup()->getKey()] = $price->getPrice();
+                }
             }
 
             /** @var \Shopware\Models\Article\Detail $variant */
@@ -1240,10 +1242,12 @@ WHERE a.active = 1 AND a.name <> '' AND ". $query . " AND ad.kind = 1 AND ad.act
                 if ($variant->getId() != $article->getMainDetail()->getId()) {
                     /** @var \Shopware\Models\Article\Price $variantPrice */
                     foreach ($variant->getPrices() as $variantPrice) {
-                        $group = $variantPrice->getCustomerGroup()->getKey();
-                        if (!empty($mainPrices[$group]) && $mainPrices[$group] !== $variantPrice->getPrice()) {
-                            $show = 1;
-                            break;
+                        if ($variantPrice->getCustomerGroup()) {
+                            $group = $variantPrice->getCustomerGroup()->getKey();
+                            if (!empty($mainPrices[$group]) && $mainPrices[$group] !== $variantPrice->getPrice()) {
+                                $show = 1;
+                                break;
+                            }
                         }
                     }
                 }

--- a/FindologicSearch/Components/Findologic/Export.php
+++ b/FindologicSearch/Components/Findologic/Export.php
@@ -7,6 +7,7 @@ use Shopware\Bundle\SearchBundle\Condition\CustomerGroupCondition;
 use Shopware\Bundle\SearchBundle\Criteria;
 use Shopware\Bundle\StoreFrontBundle\Service\Core\ContextService;
 use Shopware\Bundle\StoreFrontBundle\Struct\ProductContext;
+use Shopware\Components\LogawareReflectionHelper;
 use Shopware\Components\ProductStream\Repository;
 use Shopware\Models\Article\Article;
 use Cocur\Slugify\RuleProvider\DefaultRuleProvider;


### PR DESCRIPTION
There was a missing `use` statement for the `LogawareReflectionHelper` class and a case where the php error `Call to a member function getKey() on null` was thrown.